### PR TITLE
Fix heading level

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2020,7 +2020,7 @@ Fx Meta Instlalerの使用方法については、開発元による[Fx Meta Ins
 Firefoxのインストール後に別途アドオンをインストールすることによってカスタマイズを完了する形態であれば、[CCK2 Wizard](#cck)によってそのようなアドオンを作成することができます。
 
 
-# Firefox・Thunderbirdにアドオンをバンドルして展開したい
+## Firefox・Thunderbirdにアドオンをバンドルして展開したい
 
 キーワード：導入時初期設定
 
@@ -2030,7 +2030,7 @@ Fx Meta Instlalerの使用方法については、開発元による[Fx Meta Ins
 Firefoxのインストール後に別途アドオンをインストールすることによってカスタマイズを完了する形態であれば、[CCK2 Wizard](#cck)によってそのようなアドオンを作成することができます。
 
 
-# FirefoxにJavaやFlashなどのプラグインをバンドルして展開したい
+## FirefoxにJavaやFlashなどのプラグインをバンドルして展開したい
 
 キーワード：導入時初期設定
 


### PR DESCRIPTION
Perhaps they should be in the lower heading level than [_カスタマイズ済みのFirefox・Thunderbirdの展開_](https://github.com/mozilla-japan/enterprise/blob/master/FAQ.md#%E3%82%AB%E3%82%B9%E3%82%BF%E3%83%9E%E3%82%A4%E3%82%BA%E6%B8%88%E3%81%BF%E3%81%AEfirefoxthunderbird%E3%81%AE%E5%B1%95%E9%96%8B).
