### PR TITLE
Update CSS to hide "Restore Previous Session" from menu

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -999,6 +999,13 @@ Firefoxのセッション関連機能はある程度まで無効化すること�
 
  1. 「メモ帳」などのテキストエディタを開き、以下のスタイル指定を記述します。
     
+        @-moz-document url-prefix("chrome://browser/content/browser.xul") {
+          #historyRestoreLastSession,
+          #appMenuRestoreLastSession {
+            visibility: collapse !important;
+            -moz-user-focus: ignore !important;
+          }
+        }
         @-moz-document url-prefix("about:home"),
                        url-prefix("chrome://browser/content/abouthome/aboutHome.xhtml") {
           *|*#restorePreviousSessionSeparator,

--- a/FAQ.md
+++ b/FAQ.md
@@ -1009,7 +1009,9 @@ Firefoxのセッション関連機能はある程度まで無効化すること�
         @-moz-document url-prefix("about:home"),
                        url-prefix("chrome://browser/content/abouthome/aboutHome.xhtml") {
           *|*#restorePreviousSessionSeparator,
-          *|*#restorePreviousSession {
+          *|*#restorePreviousSession,
+          *|*[id="restorePreviousSessionSeparator"],
+          *|*[id="restorePreviousSession"] {
             visibility: collapse !important;
             -moz-user-focus: ignore !important;
           }

--- a/FAQ.md
+++ b/FAQ.md
@@ -1012,8 +1012,7 @@ Firefoxのセッション関連機能はある程度まで無効化すること�
           *|*#restorePreviousSession,
           *|*[id="restorePreviousSessionSeparator"],
           *|*[id="restorePreviousSession"] {
-            visibility: collapse !important;
-            -moz-user-focus: ignore !important;
+            display: none !important;
           }
         }
     


### PR DESCRIPTION
セッション機能無効化の一環として、以前のセッションを復元する動線をなくすためにメニューの「履歴」＞「以前のセッションを復元」を非表示にするCSSを追加しました。

また、`about:home`の設定のほうも、設定シートのPrivacy-10-2に合わせて更新しました。
https://github.com/clear-code/firefox-support-common/tree/master/configurations