### PR TITLE
Update selector for to disable private browsing

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1190,7 +1190,11 @@ UI要素を隠すためには、[globalChrome.css][]などのアドオンを使�
 
     @-moz-document url-prefix(chrome://browser/content/browser.xul) {
       #menu_newPrivateWindow,
-      #appmenu_newPrivateWindow {
+      #privatebrowsing-button,
+      #wrapper-privatebrowsing-button,
+      #key_privatebrowsing,
+      #Tools\:PrivateBrowsing,
+      #context-openlinkprivate {
         visibility: collapse !important;
         -moz-user-focus: ignore !important;
       }


### PR DESCRIPTION
プライベートブラウジング機能を無効にする項で、globalChrome.cssの設定が古くなっていたので更新しました。Firefox 31以降は更新後の設定で動くはずです。