### PR TITLE
Update link for Disable Sync

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -2307,7 +2307,7 @@ Firefoxのインストール後に別途アドオンをインストールする�
   [Disable about:config]: https://addons.mozilla.org/firefox/addon/disable-aboutconfig/
   [Disable Addons]: https://github.com/clear-code/disableaddons/releases
   [Disable Auto Update]: https://github.com/clear-code/disableupdate/releases
-  [Disable Sync]: https://addons.mozilla.org/firefox/addon/disable-sync/
+  [Disable Sync]: https://github.com/clear-code/disablesync/releases
   [Do Not Save Password]: https://addons.mozilla.org/firefox/addon/do-not-save-password/
   [DOM Inspector]: https://addons.mozilla.org/firefox/addon/dom-inspector-6622/
   [Flex Confirm Mail]: https://addons.mozilla.org/thunderbird/addon/flex-confirm-mail/


### PR DESCRIPTION
[Disable Sync](https://github.com/clear-code/disablesync)は審査が通らなくなったためaddons.mozilla.orgでの公開は停止されていますが、リンク先が変更されておらずリンク切れになっていたので、リンク先をaddons.mozilla.orgからGitHubに変更しました。